### PR TITLE
fix signature field positions not saving

### DIFF
--- a/admin/helpers/RegisterSettings.php
+++ b/admin/helpers/RegisterSettings.php
@@ -76,7 +76,6 @@ class RegisterSettings
 				register_setting($page, $id);
 				break;
 			case'pos_rot':
-				$id = $id . Settings::GLUE_PART . Settings::PART_POS_X;
 				add_settings_field($id, $label, $callback, $page, $sectionId, $field);
 				register_setting($page, $id . Settings::GLUE_PART . Settings::PART_POS_X);
 				register_setting($page, $id . Settings::GLUE_PART . Settings::PART_POS_Y);


### PR DESCRIPTION
Changed positions of the fields in `wp-admin/admin.php?page=demovoxSettings&tab=3&cln=1` were not persisted on saving, due to an ID mismatch in the Settings API. This patch should fix it.