### PR TITLE
fix success page in wrong language

### DIFF
--- a/includes/helpers/Strings.php
+++ b/includes/helpers/Strings.php
@@ -16,6 +16,7 @@ class Strings
 	public static function getPageUrl(string $signGuid, ?int $pageId = null, ?string $baseUrl = null): string
 	{
 		$pageId = $pageId ?: Settings::getCValue('use_page_as_success');
+		$pageId = i18n::getTranslatedPageId($pageId);
 		$url    = get_permalink($pageId);
 		if ($baseUrl) {
 			$lengthCut = strlen(home_url());

--- a/includes/i18n.php
+++ b/includes/i18n.php
@@ -100,4 +100,22 @@ class i18n
 		);
 	}
 
+	/**
+	 * Returns the page id of the translation of the given page id
+	 *
+	 * Uses the WPML icl_object_id function to find the translation
+	 * of the given page. Returns the original if WPML (and no
+	 * compatible plugin) are present or if no translation exists.
+	 *
+	 * @param $pageId
+	 *
+	 * @return int|mixed|null
+	 */
+	public static function getTranslatedPageId($pageId) {
+		if ($pageId && function_exists( 'icl_object_id')) {
+			return icl_object_id($pageId, 'page', true);
+		}
+
+		return $pageId;
+	}
 }


### PR DESCRIPTION
If the user fills out the form in a language other than the default, the success page is still shown in the default language. This fix
selects the appropriate translation of the success page (and others like the abroad redirect or the local initiative error redirect). It is at least compatible with WPML and Polylang.